### PR TITLE
fix: Not all `ciscoasa_nat` fields can be updated using the API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ terraform.tfstate.*
 
 # Config files for local development environment
 *.env
+
+dist/

--- a/ciscoasa/resource_ciscoasa_nat.go
+++ b/ciscoasa/resource_ciscoasa_nat.go
@@ -320,7 +320,7 @@ func resourceCiscoASANatCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 	Nat.OriginalService = objFromKindValue(d, "original_service")
 	Nat.OriginalSource = objFromKindValue(d, "original_source")
-	Nat.TranslatedDestination = objFromKindValue(d, "translate_destination")
+	Nat.TranslatedDestination = objFromKindValue(d, "translated_destination")
 	if translatedInterfaceName, ok := d.GetOk("translated_interface_name"); ok {
 		Nat.TranslatedInterface = objFromInterfaceName(translatedInterfaceName)
 	}
@@ -444,7 +444,7 @@ func resourceCiscoASANatUpdate(d *schema.ResourceData, meta interface{}) error {
 		"original_interface_name",
 		"original_service",
 		"original_source",
-		"translate_destination",
+		"translated_destination",
 		"translated_interface_name",
 		"translated_service",
 		"translated_source",
@@ -477,7 +477,7 @@ func resourceCiscoASANatUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 		Nat.OriginalService = objFromKindValue(d, "original_service")
 		Nat.OriginalSource = objFromKindValue(d, "original_source")
-		Nat.TranslatedDestination = objFromKindValue(d, "translate_destination")
+		Nat.TranslatedDestination = objFromKindValue(d, "translated_destination")
 		if translatedInterfaceName, ok := d.GetOk("translated_interface_name"); ok {
 			Nat.TranslatedInterface = objFromInterfaceName(translatedInterfaceName)
 		}

--- a/ciscoasa/resource_ciscoasa_nat.go
+++ b/ciscoasa/resource_ciscoasa_nat.go
@@ -122,11 +122,13 @@ func resourceCiscoASANat() *schema.Resource {
 					"objectRef#NetworkObj",
 					"objectRef#NetworkObjGroup",
 				}, false),
+				ForceNew: true,
 			},
 
 			"translated_source_value": {
 				Type:     schema.TypeString,
 				Optional: true,
+				ForceNew: true,
 			},
 
 			"translated_destination_kind": {
@@ -142,11 +144,13 @@ func resourceCiscoASANat() *schema.Resource {
 					"objectRef#NetworkObj",
 					"objectRef#NetworkObjGroup",
 				}, false),
+				ForceNew: true,
 			},
 
 			"translated_destination_value": {
 				Type:     schema.TypeString,
 				Optional: true,
+				ForceNew: true,
 			},
 
 			"translated_service_kind": {


### PR DESCRIPTION
The API doesn't allow updating all fields. When updating these fields we need to recreate the resource:

- `translated_destination_kind`
- `translated_destination_value`
- `translated_source_kind`
- `translated_source_value`

Also fixed a typo to match actual API field.
