### PR TITLE
fix: ASA API executes delete/create on order update which could cause race condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.5.1 (December 2, 2024)
+
+BUGFIXES
+
+- ASA API executes delete/create on order update which could cause race condition (rule ID deleted before next rule with this ID gets processed)
+  This forces Terraform to handle the delete/create following normal Terraform order
+
 ## 1.5.0 (September 16, 2024)
 
 FEATURES

--- a/ciscoasa/resource_ciscoasa_nat.go
+++ b/ciscoasa/resource_ciscoasa_nat.go
@@ -58,7 +58,7 @@ func resourceCiscoASANat() *schema.Resource {
 					"objectRef#NetworkObj",
 					"objectRef#NetworkObjGroup",
 				}, false),
-				Default: "AnyIPAddress",
+				Default:  "AnyIPAddress",
 				ForceNew: true,
 			},
 
@@ -83,7 +83,7 @@ func resourceCiscoASANat() *schema.Resource {
 					"objectRef#NetworkObj",
 					"objectRef#NetworkObjGroup",
 				}, false),
-				Default: "AnyIPAddress",
+				Default:  "AnyIPAddress",
 				ForceNew: true,
 			},
 
@@ -287,6 +287,7 @@ func resourceCiscoASANat() *schema.Resource {
 				Optional:     true,
 				Computed:     true,
 				ValidateFunc: validation.IntAtLeast(1),
+				ForceNew:     true,
 			},
 
 			"last_updated": {


### PR DESCRIPTION
ASA API executes delete/create on order update which could cause race condition (rule ID deleted before next rule with this ID gets processed)
This forces Terraform to handle the delete/create following normal Terraform order